### PR TITLE
Allow a transform function to be passed to onSubmitActions on the Long Signature form

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -31,8 +31,8 @@ function normalizeShortSig (root, transform = identity) {
   return types;
 }
 
-function normalizeLongSig (submit, success, failure) {
-  const submitCreator = typeof submit === 'string' ? creatorFactory(submit, identity) : submit;
+function normalizeLongSig (submit, success, failure, transform = identity) {
+  const submitCreator = typeof submit === 'string' ? creatorFactory(submit, transform) : submit;
   return [submitCreator, success, failure];
 }
 


### PR DESCRIPTION
I don't think it breaks any existing code, since it defaults to "identity", but let me know if there are any problems, or you don't agree with this.