### PR TITLE
Wrap error payload if needed

### DIFF
--- a/src/form-submit-saga.js
+++ b/src/form-submit-saga.js
@@ -37,7 +37,11 @@ export default (SubmissionError) => function* formSubmitSaga () {
     if (success) {
       yield call(resolve, success.payload);
     } else {
-      yield call(reject, new SubmissionError(failure.payload));
+      let reduxFormPayload = failure.payload;
+      if (!failure.payload._error) {
+        reduxFormPayload = {_error: failure.payload};
+      }
+      yield call(reject, new SubmissionError(reduxFormPayload));
     }
   }
 };

--- a/src/form-submit-saga.js
+++ b/src/form-submit-saga.js
@@ -38,7 +38,7 @@ export default (SubmissionError) => function* formSubmitSaga () {
       yield call(resolve, success.payload);
     } else {
       let reduxFormPayload = failure.payload;
-      if (!failure.payload._error) {
+      if (!('_error' in failure.payload)) {
         reduxFormPayload = {_error: failure.payload};
       }
       yield call(reject, new SubmissionError(reduxFormPayload));


### PR DESCRIPTION
It can be really unclear that redux-form needs the payload setup in a certain way for the failure case to properly pass down the error. It would be really nice when the payload was not peroprly formatted, that this would change it for you.